### PR TITLE
Add support for global lists in Trakt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,7 @@ trakt-api-kotlin-wrapper.iml
 
 target/
 
-src/test/kotlin/media/thehoard/thirdparty/api/trakt/Playground.kt
+src/test/kotlin/com/atherapp/thirdparty/api/trakt/Playground.kt
+
+.idea/
+*.iml

--- a/src/main/kotlin/com/atherapp/thirdparty/api/trakt/TraktClient.kt
+++ b/src/main/kotlin/com/atherapp/thirdparty/api/trakt/TraktClient.kt
@@ -70,14 +70,14 @@ class TraktClient internal constructor() {
             authentication.authorization = value
         }
 
-    val isValidForUseWithoutAuthorization: Boolean?
-        get() = clientId.isNullOrBlank() && !clientId!!.containsSpace()
+    val isValidForUseWithoutAuthorization: Boolean
+        get() = !clientId.isNullOrBlank() && !clientId!!.containsSpace()
 
-    val isValidForUseWithAuthorization: Boolean?
-        get() = isValidForUseWithoutAuthorization!! && authentication.isAuthorized
+    val isValidForUseWithAuthorization: Boolean
+        get() = isValidForUseWithoutAuthorization && authentication.isAuthorized
 
-    val isValidForAuthenticationProcess: Boolean?
-        get() = isValidForUseWithoutAuthorization!! && !clientSecret.isNullOrBlank() && !clientSecret!!.containsSpace()
+    val isValidForAuthenticationProcess: Boolean
+        get() = isValidForUseWithoutAuthorization && !clientSecret.isNullOrBlank() && !clientSecret!!.containsSpace()
 
     constructor(clientId: String) : this() {
         this.clientId = clientId
@@ -85,9 +85,5 @@ class TraktClient internal constructor() {
 
     constructor(clientId: String, clientSecret: String) : this(clientId) {
         this.clientSecret = clientSecret
-    }
-
-    companion object {
-        internal val MAIN_THREAD_POOL = Executors.newCachedThreadPool()
     }
 }

--- a/src/main/kotlin/com/atherapp/thirdparty/api/trakt/TraktClient.kt
+++ b/src/main/kotlin/com/atherapp/thirdparty/api/trakt/TraktClient.kt
@@ -29,6 +29,8 @@ class TraktClient internal constructor() {
 
     val genres: TraktGenresModule = TraktGenresModule(this)
 
+    val lists: TraktListsModule = TraktListsModule(this)
+
     val movies: TraktMoviesModule = TraktMoviesModule(this)
 
     val networks: TraktNetworksModule = TraktNetworksModule(this)

--- a/src/main/kotlin/com/atherapp/thirdparty/api/trakt/modules/TraktCommentsModule.kt
+++ b/src/main/kotlin/com/atherapp/thirdparty/api/trakt/modules/TraktCommentsModule.kt
@@ -38,11 +38,11 @@ class TraktCommentsModule internal constructor(override val client: TraktClient)
             return CompletableFuture.completedFuture(listOf())
 
         var i = 0
-        val tasks = Array(commentIds.size, { getCommentAsync(commentIds[i++]) })
+        val tasks = Array(commentIds.size) { getCommentAsync(commentIds[i++]) }
 
         return CompletableFuture.supplyAsync {
             i = 0
-            List(tasks.size, { tasks[i++].get() })
+            List(tasks.size) { tasks[i++].get() }
         }
     }
 

--- a/src/main/kotlin/com/atherapp/thirdparty/api/trakt/modules/TraktListsModule.kt
+++ b/src/main/kotlin/com/atherapp/thirdparty/api/trakt/modules/TraktListsModule.kt
@@ -1,0 +1,27 @@
+package com.atherapp.thirdparty.api.trakt.modules
+
+import com.atherapp.thirdparty.api.trakt.TraktClient
+import com.atherapp.thirdparty.api.trakt.authentication.TraktAuthorization
+import com.atherapp.thirdparty.api.trakt.objects.get.users.lists.TraktList
+import com.atherapp.thirdparty.api.trakt.requests.handler.RequestHandler
+import com.atherapp.thirdparty.api.trakt.requests.lists.ListsPopularRequest
+import com.atherapp.thirdparty.api.trakt.requests.lists.ListsTrendingRequest
+import com.atherapp.thirdparty.api.trakt.requests.parameters.TraktPagedParameters
+import com.atherapp.thirdparty.api.trakt.responses.TraktPagedResponse
+import java.util.concurrent.CompletableFuture
+
+class TraktListsModule(override val client: TraktClient) : TraktModule {
+    fun getPopularListsAsync(
+            pagedParameters: TraktPagedParameters? = null,
+            requestAuthorization: TraktAuthorization = client.authorization
+    ): CompletableFuture<TraktPagedResponse<TraktList>> {
+        return RequestHandler(client).executePagedRequestAsync(ListsPopularRequest(pagedParameters?.page, pagedParameters?.limit), requestAuthorization)
+    }
+
+    fun getTrendingListsAsync(
+            pagedParameters: TraktPagedParameters? = null,
+            requestAuthorization: TraktAuthorization = client.authorization
+    ): CompletableFuture<TraktPagedResponse<TraktList>> {
+        return RequestHandler(client).executePagedRequestAsync(ListsTrendingRequest(pagedParameters?.page, pagedParameters?.limit), requestAuthorization)
+    }
+}

--- a/src/main/kotlin/com/atherapp/thirdparty/api/trakt/requests/lists/ListsRequests.kt
+++ b/src/main/kotlin/com/atherapp/thirdparty/api/trakt/requests/lists/ListsRequests.kt
@@ -1,0 +1,34 @@
+package com.atherapp.thirdparty.api.trakt.requests.lists
+
+import com.atherapp.thirdparty.api.trakt.objects.get.users.lists.TraktList
+import com.atherapp.thirdparty.api.trakt.requests.base.AGetRequestHasResponse
+import com.atherapp.thirdparty.api.trakt.requests.interfaces.ISupportsPagination
+
+internal abstract class AbstractListsRequest(
+        override var page: Int?,
+        override var limit: Int?
+) : AGetRequestHasResponse<TraktList>(TraktList::class), ISupportsPagination {
+    override val uriPathParameters: Map<String, String>?
+        get() = hashMapOf<String, String>().apply {
+            if (page != null)
+                this["page"] = page!!.toString()
+            if (limit != null)
+                this["limit"] = limit!!.toString()
+        }
+
+    override fun validate(variableName: String) {}
+}
+
+internal class ListsPopularRequest(
+        override var page: Int? = null,
+        override var limit: Int? = null
+) : AbstractListsRequest(page, limit) {
+    override val uriTemplate: String = "lists/popular{?page,limit}"
+}
+
+internal class ListsTrendingRequest(
+        override var page: Int? = null,
+        override var limit: Int? = null
+) : AbstractListsRequest(page, limit) {
+    override val uriTemplate: String = "lists/trending{?page,limit}"
+}

--- a/src/test/kotlin/com/atherapp/thirdparty/api/trakt/TraktClientTest.kt
+++ b/src/test/kotlin/com/atherapp/thirdparty/api/trakt/TraktClientTest.kt
@@ -1,0 +1,91 @@
+package com.atherapp.thirdparty.api.trakt
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class TraktClientTest {
+    companion object {
+        const val VALID_CLIENT_ID = "CLIENT_ID"
+        const val VALID_CLIENT_SECRET = "CLIENT_SECRET"
+
+        const val INVALID_CLIENT_ID = "CLIENT ID"
+        const val INVALID_CLIENT_SECRET = "CLIENT SECRET"
+    }
+
+    @Test
+    fun `test default construction`() {
+        val client = TraktClient().run {
+            assertNotNull(configuration)
+            assertNotNull(authentication)
+            assertNotNull(oAuth)
+            assertNotNull(deviceAuth)
+            assertNotNull(calendars)
+            assertNotNull(checkin)
+            assertNotNull(certifications)
+            assertNotNull(comments)
+            assertNotNull(genres)
+            assertNotNull(movies)
+            assertNotNull(networks)
+            assertNotNull(people)
+            assertNotNull(recommendations)
+            assertNotNull(scrobble)
+            assertNotNull(search)
+            assertNotNull(shows)
+            assertNotNull(seasons)
+            assertNotNull(episodes)
+            assertNotNull(sync)
+            assertNotNull(users)
+
+            assertNull(clientId)
+            assertNull(clientSecret)
+
+            assertNotNull(authorization)
+
+            assertFalse { isValidForUseWithoutAuthorization }
+            assertFalse { isValidForUseWithAuthorization }
+            assertFalse { isValidForAuthenticationProcess }
+        }
+    }
+
+    @Test
+    fun `test invalid client`() {
+        val client = TraktClient(
+                clientId = INVALID_CLIENT_ID,
+                clientSecret = INVALID_CLIENT_SECRET
+        ).run {
+            assertFalse { isValidForUseWithoutAuthorization }
+            assertFalse { isValidForUseWithAuthorization }
+            assertFalse { isValidForAuthenticationProcess }
+        }
+    }
+
+    /**
+     * Test a valid client ID with an invalid secret
+     */
+    @Test
+    fun `test semivalid client`() {
+        val client = TraktClient(
+                clientId = VALID_CLIENT_ID,
+                clientSecret = INVALID_CLIENT_SECRET
+        ).run {
+            assertTrue { isValidForUseWithoutAuthorization }
+            assertFalse { isValidForUseWithAuthorization }
+            assertFalse { isValidForAuthenticationProcess }
+        }
+    }
+
+    @Test
+    fun `test valid client`() {
+        val client = TraktClient(
+                clientId = VALID_CLIENT_ID,
+                clientSecret = VALID_CLIENT_SECRET
+        ).run {
+            assertTrue { isValidForUseWithoutAuthorization }
+            assertFalse { isValidForUseWithAuthorization }
+            assertTrue { isValidForAuthenticationProcess }
+        }
+    }
+}

--- a/src/test/kotlin/com/atherapp/thirdparty/api/trakt/authentication/TraktAuthenticationTest.kt
+++ b/src/test/kotlin/com/atherapp/thirdparty/api/trakt/authentication/TraktAuthenticationTest.kt
@@ -1,0 +1,51 @@
+package com.atherapp.thirdparty.api.trakt.authentication
+
+import com.atherapp.thirdparty.api.trakt.TraktClient
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.*
+import kotlin.test.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class TraktAuthenticationTest {
+
+    lateinit var client: TraktClient
+    lateinit var authentication: TraktAuthentication
+
+    @BeforeAll
+    fun init() {
+        client = TraktClient()
+        authentication = client.authentication
+    }
+
+    @Test
+    fun `test client`() {
+        assertNotNull(client)
+        assertNotNull(authentication.client)
+    }
+
+    @Test
+    fun `test default construction`() {
+        authentication.run {
+            assertNull(oAuthAuthorizationCode)
+            UUID.fromString(antiForgeryToken)
+            assertNotNull(authorization)
+            assertNotNull(device)
+            assertNull(clientId)
+            assertNull(clientSecret)
+            assertEquals(redirectUri, "urn:ietf:wg:oauth:2.0:oob")
+            assertFalse { isAuthorized }
+        }
+    }
+
+    @Test
+    fun `test authorization checks`() {
+        authentication.run {
+            assertEquals(checkIfAuthorizationIsExpiredOrWasRevokedAsync(false).get(), true to null)
+            assertFails { checkIfAuthorizationIsExpiredOrWasRevokedAsync(null, false) }
+            assertFails { checkIfAccessTokenWasRevokedOrIsNotValidAsync("") }
+
+        }
+    }
+}


### PR DESCRIPTION
This adds support for Trakt lists, as per the API Documentation: https://trakt.docs.apiary.io/#reference/lists/trending

Adds the following endpoints:
* `lists/popular`
* `lists/trending`

Both support pagination, but no additional parameters.